### PR TITLE
point out percent encoding issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Digest::MD5.hexdigest(signature_base)
 Here are the following definitions of each variable in the above example:
 
 - `token`: The alphanumeric Secure URL Token pertaining to the specific Source. It can be found in the [imgix web dashboard](https://webapp.imgix.com/source).
-- `path`: The path of component of the final imgix URL including the leading slash, e.g. `/users/1.png` or `/http%3A%2F%2Favatars.com%2Fjohn-smith.png`.
+- `path`: The path of component of the final imgix URL including the leading slash, e.g. `/users/1.png` or `/http%3A%2F%2Favatars.com%2Fjohn-smith.png`.  Special characters in the path (for example UTF-8 encoded codepoints) must remain percent encoded.
 - `query`: The query string of the imgix URL parameters, leading with the `?`, e.g. `?w=400&h=300`. If there are no query parameters, this should be left out of the signature base.
 
 ### Examples


### PR DESCRIPTION
I just found that if you have codepoints outside the ascii range, they are encoded by the browser, they also need to be encoded before md5sum-ing.  This isn't 100% clear from the docs, unless you're looking carefully.  So just adding this as a heads-up to anyone in future.

Some [helpful libraries](http://docs.oracle.com/javase/7/docs/api/java/net/URI.html#getPath%28%29) will decode them back to unicode for you, which is not actually what you want. [try getRawPath instead](http://docs.oracle.com/javase/7/docs/api/java/net/URI.html#getPath%28%29)
