### PR TITLE
Wrong example signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Given:
 The resulting signature should be:
 
 ```
-d687aadb76459935ca2e69afc9d8a9c3
+c7b86f666a832434dd38577e38cf86d1
 ```
 
 This makes the final URL:


### PR DESCRIPTION
Howdy

As I was testing a little library I am creating in .Net I noticed that the example signature when adding width and height was wrong.
The one in the url was correct though.
